### PR TITLE
Feat/devtools on seperate nuxt dev server

### DIFF
--- a/layer/modules/mail-devtools/devtools-client/app.vue
+++ b/layer/modules/mail-devtools/devtools-client/app.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 
-definePageMeta({
-  layout: "email-devtools",
-});
-
 interface Email {
   id: string;
   to: string;
@@ -83,11 +79,6 @@ function selectEmail(email: Email) {
 
 function formatDate(dateString: string) {
   return new Date(dateString).toLocaleString();
-}
-
-function truncateText(text: string, maxLength: number = 50) {
-  if (!text) return "";
-  return text.length > maxLength ? text.substring(0, maxLength) + "..." : text;
 }
 
 onMounted(() => {

--- a/layer/modules/mail-devtools/devtools-client/nuxt.config.ts
+++ b/layer/modules/mail-devtools/devtools-client/nuxt.config.ts
@@ -1,0 +1,14 @@
+export default defineNuxtConfig({
+  ssr: false,
+  modules: ["@nuxt/devtools-ui-kit"],
+  vite: {
+    server: {
+      proxy: {
+        "/api": {
+          target: `http://localhost:${process.env.MAIN_SERVER_PORT || "3000"}`,
+          changeOrigin: true,
+        },
+      },
+    },
+  },
+});

--- a/layer/modules/mail-devtools/devtools-client/nuxt.config.ts
+++ b/layer/modules/mail-devtools/devtools-client/nuxt.config.ts
@@ -4,6 +4,10 @@ export default defineNuxtConfig({
   vite: {
     server: {
       proxy: {
+        // Proxy the api requests to the main server
+        // WHY? Because we can add the API endpoints to the main app
+        // and easily use the useEmail composable within it without installing in the devtools dev server
+        // plus this let's the consuming app's nuxt.config.ts configure the email provider, storage base, etc
         "/api": {
           target: `http://localhost:${process.env.MAIN_SERVER_PORT || "3000"}`,
           changeOrigin: true,

--- a/layer/modules/mail-devtools/devtools.ts
+++ b/layer/modules/mail-devtools/devtools.ts
@@ -1,9 +1,13 @@
-import type { Nuxt } from "nuxt/schema";
 import type { Resolver } from "@nuxt/kit";
+import type { Nuxt } from "nuxt/schema";
+import { spawn, type ChildProcess } from "node:child_process";
 
-const DEVTOOLS_UI_ROUTE = "/__email-devtools";
+const DEVTOOLS_UI_ROUTE = "/";
+const DEVTOOLS_UI_LOCAL_PORT = 3030;
 
 export function setupDevToolsUI(nuxt: Nuxt, resolver: Resolver) {
+  startDevtoolsServer(nuxt, resolver);
+
   nuxt.hook("devtools:customTabs", (tabs) => {
     tabs.push({
       // unique identifier
@@ -15,8 +19,59 @@ export function setupDevToolsUI(nuxt: Nuxt, resolver: Resolver) {
       // iframe view
       view: {
         type: "iframe",
-        src: DEVTOOLS_UI_ROUTE,
+        src: `http://localhost:${DEVTOOLS_UI_LOCAL_PORT}${DEVTOOLS_UI_ROUTE}`,
       },
     });
   });
+}
+
+/**
+ * Start the mail devtools as a new nuxt app running in a separate process
+ * Parallel to the main server
+ *
+ * @param nuxt
+ * @param resolver
+ */
+function startDevtoolsServer(nuxt: Nuxt, resolver: Resolver) {
+  const clientPath = resolver.resolve("./devtools-client");
+
+  let mainServerPort: number | undefined;
+  let devtoolsProcess: ChildProcess | undefined;
+
+  // Hook into when the main server starts listening to get the actual port
+  nuxt.hook("listen", (server, { address }) => {
+    mainServerPort = address.port;
+
+    // Start the devtools client with the main server port as an environment variable
+    if (!devtoolsProcess) startDevtoolsProcess();
+  });
+
+  function startDevtoolsProcess() {
+    if (!mainServerPort) throw new Error("Main server port not found");
+    devtoolsProcess = spawn(
+      "npx",
+      ["nuxi", "dev", "--port", DEVTOOLS_UI_LOCAL_PORT.toString()],
+      {
+        cwd: clientPath,
+        stdio: "ignore",
+        env: {
+          ...process.env,
+          MAIN_SERVER_PORT: mainServerPort.toString(),
+        },
+      }
+    );
+  }
+
+  // If server is already listening start immediately
+  if (mainServerPort) startDevtoolsProcess();
+
+  function killDevtoolsProcess() {
+    if (devtoolsProcess && !devtoolsProcess.killed) {
+      devtoolsProcess.kill("SIGTERM");
+    }
+  }
+
+  process.on("exit", killDevtoolsProcess);
+  process.on("SIGINT", killDevtoolsProcess);
+  process.on("SIGTERM", killDevtoolsProcess);
 }

--- a/layer/modules/mail-devtools/index.ts
+++ b/layer/modules/mail-devtools/index.ts
@@ -1,15 +1,10 @@
-import { defineNuxtModule, addPlugin, createResolver } from "@nuxt/kit";
+import { defineNuxtModule, createResolver } from "@nuxt/kit";
 import { setupDevToolsUI } from "./devtools";
 
 // Module options TypeScript interface definition
-export interface ModuleOptions {
-  /**
-   * Enable Nuxt Devtools integration
-   *
-   * @default true
-   */
-  devtools: boolean;
-}
+// disable eslint rule for empty object type for now in case we need to add options later
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ModuleOptions {}
 
 export default defineNuxtModule<ModuleOptions>({
   meta: {
@@ -17,19 +12,11 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: "emailDevtools",
   },
   // Default configuration options of the Nuxt module
-  defaults: {
-    devtools: true,
-  },
+  defaults: {},
   setup(options, nuxt) {
     const resolver = createResolver(import.meta.url);
 
-    // Add route rule for the email devtools
-    // Prevent the devtools from being rendered on the server
-    nuxt.options.routeRules = nuxt.options.routeRules || {};
-    nuxt.options.routeRules["/__email-devtools"] = {
-      ssr: false,
-    };
-
-    if (options.devtools) setupDevToolsUI(nuxt, resolver);
+    if (nuxt.options.devtools.enabled && process.env.NODE_ENV === "development")
+      setupDevToolsUI(nuxt, resolver);
   },
 });

--- a/layer/nuxt.config.ts
+++ b/layer/nuxt.config.ts
@@ -31,5 +31,5 @@ export default defineNuxtConfig({
       },
     },
   },
-  modules: ["@nuxt/eslint", "@nuxt/devtools-ui-kit"],
+  modules: ["@nuxt/eslint"],
 });

--- a/layer/package.json
+++ b/layer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nuxt-email-layer",
   "type": "module",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "./nuxt.config.ts",
   "scripts": {
     "prepare": "nuxt prepare",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "1.0.0",
   "private": true,
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.18.0",
   "scripts": {
     "dev": "pnpm play:dev",
     "play:dev": "pnpm --filter playground run dev",
@@ -28,12 +28,12 @@
     "prepare": "pnpm -r prepare"
   },
   "devDependencies": {
-    "nuxt-email-layer": "workspace:*",
     "@nuxt/eslint": "latest",
     "@nuxt/test-utils": "^3.19.2",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.34.0",
     "happy-dom": "^18.0.1",
+    "nuxt-email-layer": "workspace:*",
     "playwright-core": "^1.55.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"


### PR DESCRIPTION
Run mailcatcher devtools on a separate Nuxt dev server so that we can still access mail catcher even on Nuxt apps without Vue router (no `pages` directory)  